### PR TITLE
Prevent startup issues because of slow network

### DIFF
--- a/templates/csync2.cfg.j2
+++ b/templates/csync2.cfg.j2
@@ -1,4 +1,5 @@
 nossl * *;
+lock-timeout 60;
 group web
 {
   {% for host in groups['front'] -%}


### PR DESCRIPTION
Should fix the issue
`Database backend is exceedingly busy => Terminating (requesting retry)`